### PR TITLE
Prevent reuse of otp

### DIFF
--- a/demo/db/migrate/20170516191259_add_lastotpat_to_users.rb
+++ b/demo/db/migrate/20170516191259_add_lastotpat_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastotpatToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :last_otp_at, :datetime
+  end
+end

--- a/demo/db/migrate/20170516191259_add_lastotpat_to_users.rb
+++ b/demo/db/migrate/20170516191259_add_lastotpat_to_users.rb
@@ -1,5 +1,5 @@
 class AddLastotpatToUsers < ActiveRecord::Migration
   def change
-    add_column :users, :last_otp_at, :datetime
+    add_column :users, :last_otp_at, :integer
   end
 end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20140516191259) do
     t.string   "encrypted_otp_secret_salt"
     t.integer  "consumed_timestep"
     t.boolean  "otp_required_for_login"
+    t.integer  "last_otp_at"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'attr_encrypted', '>= 1.3', '< 4', '!= 2'
   s.add_runtime_dependency 'devise',         '~> 4.0'
-  s.add_runtime_dependency 'rotp',           '~> 2.0'
+  s.add_runtime_dependency 'rotp',           '~> 3.0'
 
   s.add_development_dependency 'activemodel'
   s.add_development_dependency 'bundler',    '> 1.0'

--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'faker'
   s.add_development_dependency 'timecop'
+  s.add_development_dependency 'byebug'
 end

--- a/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
@@ -6,7 +6,7 @@ shared_examples 'two_factor_authenticatable' do
 
   describe 'required_fields' do
     it 'should have the attr_encrypted fields for otp_secret' do
-      expect(Devise::Models::TwoFactorAuthenticatable.required_fields(subject.class)).to contain_exactly(:encrypted_otp_secret, :encrypted_otp_secret_iv, :encrypted_otp_secret_salt, :consumed_timestep)
+      expect(Devise::Models::TwoFactorAuthenticatable.required_fields(subject.class)).to contain_exactly(:encrypted_otp_secret, :encrypted_otp_secret_iv, :encrypted_otp_secret_salt, :consumed_timestep, :last_otp_at)
     end
   end
 
@@ -104,6 +104,25 @@ shared_examples 'two_factor_authenticatable' do
     it 'should return uri with issuer option' do
       expect(subject.otp_provisioning_uri(account, issuer: issuer)).to match(%r{otpauth://totp/#{issuer}:#{account}\?.*secret=\w{#{otp_secret_length}}(&|$)})
       expect(subject.otp_provisioning_uri(account, issuer: issuer)).to match(%r{otpauth://totp/#{issuer}:#{account}\?.*issuer=#{issuer}(&|$)})
+    end
+  end
+
+  context 'given a valid OTP used multiple times within the allowed drift' do
+    let(:consumed_otp) { ROTP::TOTP.new(subject.otp_secret).at(Time.now) }
+
+    before do
+      subject.validate_and_consume_otp!(consumed_otp)
+    end
+
+    context 'after the otp interval' do
+      before do
+        Timecop.travel(subject.otp.interval.seconds.from_now)
+      end
+
+      # This currently fails!
+      it 'fails to validate' do
+        expect(subject.validate_and_consume_otp!(consumed_otp)).to be false
+      end
     end
   end
 end

--- a/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
@@ -119,7 +119,7 @@ shared_examples 'two_factor_authenticatable' do
         Timecop.travel(subject.otp.interval.seconds.from_now)
       end
 
-      # This currently fails!
+      # This spec tests that reuse of the OTP is not allowed
       it 'fails to validate' do
         expect(subject.validate_and_consume_otp!(consumed_otp)).to be false
       end

--- a/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
@@ -102,8 +102,8 @@ shared_examples 'two_factor_authenticatable' do
     end
 
     it 'should return uri with issuer option' do
-      expect(subject.otp_provisioning_uri(account, issuer: issuer)).to match(%r{otpauth://totp/#{account}\?.*secret=\w{#{otp_secret_length}}(&|$)})
-      expect(subject.otp_provisioning_uri(account, issuer: issuer)).to match(%r{otpauth://totp/#{account}\?.*issuer=#{issuer}(&|$)})
+      expect(subject.otp_provisioning_uri(account, issuer: issuer)).to match(%r{otpauth://totp/#{issuer}:#{account}\?.*secret=\w{#{otp_secret_length}}(&|$)})
+      expect(subject.otp_provisioning_uri(account, issuer: issuer)).to match(%r{otpauth://totp/#{issuer}:#{account}\?.*issuer=#{issuer}(&|$)})
     end
   end
 end

--- a/lib/generators/devise_two_factor/devise_two_factor_generator.rb
+++ b/lib/generators/devise_two_factor/devise_two_factor_generator.rb
@@ -23,7 +23,7 @@ module DeviseTwoFactor
                                 "encrypted_otp_secret_iv:string",
                                 "encrypted_otp_secret_salt:string",
                                 "consumed_timestep:integer",
-                                "last_otp_at:datetime",
+                                "last_otp_at:integer",
                                 "otp_required_for_login:boolean"
                               ]
 

--- a/lib/generators/devise_two_factor/devise_two_factor_generator.rb
+++ b/lib/generators/devise_two_factor/devise_two_factor_generator.rb
@@ -23,6 +23,7 @@ module DeviseTwoFactor
                                 "encrypted_otp_secret_iv:string",
                                 "encrypted_otp_secret_salt:string",
                                 "consumed_timestep:integer",
+                                "last_otp_at:datetime",
                                 "otp_required_for_login:boolean"
                               ]
 

--- a/spec/devise/models/two_factor_authenticatable_spec.rb
+++ b/spec/devise/models/two_factor_authenticatable_spec.rb
@@ -11,6 +11,7 @@ class TwoFactorAuthenticatableDouble
   devise :two_factor_authenticatable, :otp_secret_encryption_key => 'test-key'*4
 
   attr_accessor :consumed_timestep
+  attr_accessor :last_otp_at
 
   def save(validate)
     # noop for testing
@@ -36,6 +37,7 @@ class TwoFactorAuthenticatableWithCustomizeAttrEncryptedDouble
   devise :two_factor_authenticatable, :otp_secret_encryption_key => 'test-key'*4
 
   attr_accessor :consumed_timestep
+  attr_accessor :last_otp_at
 
   def save(validate)
     # noop for testing


### PR DESCRIPTION
### Issue

The `devise-two-factor` gem does something odd, which is to reject valid 2FA codes if they've been used in the current timestep, but allow them outside of the current timestep.

Context: If your 2FA code is X at time T, you can enter X at time T+30 because OTP implementations allow you a grace period to account for clock drift. This should only be allowed if the code has not been used.  You should be able to enter X at T+30 only if you did **not** enter X at an earlier time.  Otherwise these codes are not one-time passwords. 

The `devise-two-factor` gem correctly rejects X at time T after it has been entered, but allows X again in the next timestep (T+30), which is a security issue.  There is an open issue about this, but it hasn't been merged yet: tinfoil/devise-two-factor#106

### Solution

This PR adds commits from onemanstartup/devise-two-factor@d74da6e to track previously consumed OTPs and disallow reusing them.  It also adds an additional commit to fix a bug in the schema definition and update a comment.