### PR TITLE
Revert "[CIVP-13270] Pinning attr_encrypted to v1.3.X"

### DIFF
--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'railties'
   s.add_runtime_dependency 'activesupport'
-  s.add_runtime_dependency 'attr_encrypted', '>= 1.3', '< 2', '!= 2'
+  s.add_runtime_dependency 'attr_encrypted', '>= 1.3', '< 4', '!= 2'
   s.add_runtime_dependency 'devise',         '~> 4.0'
   s.add_runtime_dependency 'rotp',           '~> 3.0'
 

--- a/spec/devise/models/two_factor_authenticatable_spec.rb
+++ b/spec/devise/models/two_factor_authenticatable_spec.rb
@@ -66,15 +66,15 @@ describe ::Devise::Models::TwoFactorAuthenticatable do
 
     describe 'otp_secret options' do
       it 'should be of the key' do
-        expect(subject.evaluated_attr_encrypted_options_for(:otp_secret)[:key]).to eq('test-key'*8)
+        expect(subject.encrypted_attributes[:otp_secret][:key]).to eq('test-key'*8)
       end
 
       it 'should be of the mode' do
-        expect(subject.evaluated_attr_encrypted_options_for(:otp_secret)[:mode]).to eq(:per_attribute_iv_and_salt)
+        expect(subject.encrypted_attributes[:otp_secret][:mode]).to eq(:per_attribute_iv_and_salt)
       end
 
       it 'should be of the mode' do
-        expect(subject.evaluated_attr_encrypted_options_for(:otp_secret)[:algorithm]).to eq('aes-256-cbc')
+        expect(subject.encrypted_attributes[:otp_secret][:algorithm]).to eq('aes-256-cbc')
       end
     end
   end


### PR DESCRIPTION
Reverts civisanalytics/devise-two-factor#4

`attr_encrypted` 3.0 seems to be working fine for us.